### PR TITLE
refactor: Change approach for extending scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,25 @@ Then, update your **package.json** with the following:
 }
 ```
 
+## Extending/Replacing the script configuration
+
+To extend or replace the scripts configurations, you have to create an **.exos.config.js** file exporting the following:
+
+```js
+module.exports = {
+  scripts: {
+    lint: (config, { env }) => {
+      // TODO: Modify the config or replace it entirely
+      return config;
+    },
+    start: (config, { env }) => {
+      // TODO: Modify the config or replace it entirely
+      return config;
+    },
+  },
+};
+```
+
+You can modify the configuration of all the scripts this way (`lint`, `start`, `test`, `start`,`build`) by passing a function that receives the default config used by **exos-scripts** and the configuration variables used (in the example above, `env` tells you the value of `NODE_ENV` used by the script), and returns the modified configuration.
+
 🚀!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exos-scripts",
-  "version": "0.5.1",
+  "version": "0.0.0-semantic-release",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/common/getConfigToUse.ts
+++ b/src/common/getConfigToUse.ts
@@ -1,28 +1,32 @@
 import fs from "fs";
 import path from "path";
 import { CONFIG_PATH } from "./paths";
-import type { RulesetResult } from "./types";
+import type { ExosConfig, ExosScripts } from "../common/types";
 
 /**
  * Retrieves the configuration to use.
- * @param configFileName The config file name
+ * @param scriptName The script name
  * @param defaultConfig The default config to use
  * @returns
  * If there is a custom configuration, we will call this file and send the default config.
  * Otherwise, we will simply return the default one.
  */
-function getConfigToUse<T>(configFileName: string, defaultConfig: T): RulesetResult<T> {
-  const customConfigPath: string = path.resolve(CONFIG_PATH, configFileName);
-  const customConfigExists: boolean = fs.existsSync(customConfigPath);
+function getConfigToUse<T>(scriptName: ExosScripts, defaultConfig: T): T {
+  const exosConfigPath: string = path.resolve(CONFIG_PATH);
+  const exosConfigPathExists: boolean = fs.existsSync(exosConfigPath);
 
-  if (!customConfigExists) {
-    return { result: defaultConfig, isCustom: false };
+  if (!exosConfigPathExists) {
+    return defaultConfig;
   }
 
-  // We need to require this dynamically as the command is chosen by the user
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const customConfig = require(customConfigPath)(defaultConfig, { env: process.env.NODE_ENV });
-  return { isCustom: true, result: customConfig, customPath: customConfigPath };
+  const exosConfig = require(exosConfigPath) as ExosConfig;
+  const exosScriptCustomConfig = exosConfig.scripts && exosConfig.scripts[scriptName];
+
+  if (!exosScriptCustomConfig) {
+    return defaultConfig;
+  }
+
+  return exosScriptCustomConfig(defaultConfig, { env: process.env.NODE_ENV }) as T;
 }
 
 export default getConfigToUse;

--- a/src/common/getFilesToUse.ts
+++ b/src/common/getFilesToUse.ts
@@ -1,4 +1,3 @@
-import type { RulesetResult } from "./types";
 import getArgumentValue from "./getArgumentValue";
 
 /**
@@ -9,16 +8,16 @@ import getArgumentValue from "./getArgumentValue";
  * If there is a custom configuration, we will call this file and send the default config.
  * Otherwise, we will simply return the default one.
  */
-function getFilesToUse(filesArg: string, defaultValue: string[]): RulesetResult<string[]> {
+function getFilesToUse(filesArg: string, defaultValue: string[]): string[] {
   // Check if the --files="globPattern1","globPattern2" argument is present
   // If it is, use it to identify the files to test against
   const filesArgument = getArgumentValue(process.argv, "files");
 
   if (!filesArgument) {
-    return { result: defaultValue, isCustom: false };
+    return defaultValue;
   }
 
-  return { isCustom: true, customPath: filesArg, result: filesArgument.split(",") };
+  return filesArgument.split(",");
 }
 
 export default getFilesToUse;

--- a/src/common/paths.ts
+++ b/src/common/paths.ts
@@ -2,7 +2,7 @@ import path from "path";
 
 const ROOT_PATH = path.resolve(process.cwd());
 const NODE_MODULES_PATH = path.resolve(ROOT_PATH, "node_modules");
-const CONFIG_PATH = path.resolve(ROOT_PATH, "config");
+const CONFIG_PATH = path.resolve(ROOT_PATH, "exos.config.js");
 const SOURCE_PATH = path.resolve(ROOT_PATH, "src");
 const ASSETS_PATH = path.resolve(ROOT_PATH, "public");
 const OUTPUT_PATH = path.resolve(ROOT_PATH, "dist");

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,12 +1,30 @@
+/** Exos Scripts names */
+export enum ExosScripts {
+  "start" = "start",
+  "build" = "build",
+  "lint" = "lint",
+  "stylelint" = "stylelint",
+  "test" = "test",
+}
+
+/** Configuration function of the scripts */
+type ExosScriptConfigFn<T> = (defaultConfig: T, envVariables: { env?: string }) => T;
+
 /**
- * Result of a check to use either a default ruleset
- * or a custom ruleset sent via process.args
+ * Exos configuration file
  */
-export interface RulesetResult<T> {
-  /** The result of the rule check */
-  result: T;
-  /** True if the resolved ruleset is custom. False if it is the default */
-  isCustom: boolean;
-  /** The path of the custom ruleset to use */
-  customPath?: string;
+export interface ExosConfig {
+  /** Custom configuration for the scripts */
+  scripts: {
+    /** Configuration function for the lint script */
+    lint: ExosScriptConfigFn<{}>;
+    /** Configuration function for the stylelint script */
+    stylelint: ExosScriptConfigFn<{}>;
+    /** Configuration function for the start script */
+    start: ExosScriptConfigFn<{}>;
+    /** Configuration function for the build script */
+    build: ExosScriptConfigFn<{}>;
+    /** Configuration function for the test script */
+    test: ExosScriptConfigFn<{}>;
+  };
 }

--- a/src/exos-scripts.ts
+++ b/src/exos-scripts.ts
@@ -1,15 +1,12 @@
 import chalk from "chalk";
 import path from "path";
 import spawn from "cross-spawn";
+import { ExosScripts } from "./common/types";
 
-const availableScripts: string[] = ["build", "start", "lint", "test", "stylelint"];
-
-export default function exosScripts(scriptName: string, args: string[]) {
-  const isScriptAvailable = availableScripts.find((item) => item.indexOf(scriptName) !== -1) !== undefined;
-
-  if (!isScriptAvailable) {
+export default function exosScripts(scriptName: string, args: string[]): void {
+  if (!(scriptName in ExosScripts)) {
     console.log(chalk.red(`Script ${scriptName} doesn't exist.`));
-    console.log(chalk.red(`Valid scripts are: ${availableScripts.join(", ")}.`));
+    console.log(chalk.red(`Valid scripts are: ${Object.keys(ExosScripts).join(", ")}.`));
     console.log();
     return;
   }

--- a/src/scripts/build/build.ts
+++ b/src/scripts/build/build.ts
@@ -8,12 +8,13 @@ import chalk from "chalk";
 import webpack from "webpack";
 import webpackConfig from "../../webpack/webpack.config";
 import getConfigToUse from "../../common/getConfigToUse";
+import { ExosScripts } from "../../common/types";
 
-const configToUse = getConfigToUse<webpack.Configuration>("build.js", webpackConfig);
-console.log(configToUse.isCustom ? `Found custom build config at ${configToUse.customPath}` : "Using default build config");
+const configToUse = getConfigToUse<webpack.Configuration>(ExosScripts.build, webpackConfig);
+console.log(configToUse !== webpackConfig ? `Found custom build config` : "Using default build config");
 
 // For more information, see https://webpack.js.org/api/node/
-const compiler = webpack(configToUse.result);
+const compiler = webpack(configToUse);
 
 compiler.run((err: Error, stats: webpack.Stats) => {
   // The err object will only contain webpack-related issues, such as misconfiguration, etc.

--- a/src/scripts/start/start.ts
+++ b/src/scripts/start/start.ts
@@ -8,15 +8,16 @@ import webpack from "webpack";
 import webpackDevServer from "webpack-dev-server";
 import webpackConfig from "../../webpack/webpack.config";
 import getConfigToUse from "../../common/getConfigToUse";
+import { ExosScripts } from "../../common/types";
 
-const configToUse = getConfigToUse<webpack.Configuration>("start.js", webpackConfig);
-console.log(configToUse.isCustom ? `Found custom start config at ${configToUse.customPath}` : "Using default start config");
+const configToUse = getConfigToUse<webpack.Configuration>(ExosScripts.start, webpackConfig);
+console.log(configToUse !== webpackConfig ? `Found custom start config` : "Using default start config");
 
 // For more information, see https://webpack.js.org/api/node/
-const compiler = webpack(configToUse.result);
-const devServer = new webpackDevServer(compiler, configToUse.result.devServer);
-const port = configToUse.result.devServer?.port || 8080;
-const host = configToUse.result.devServer?.host || "0.0.0.0";
+const compiler = webpack(configToUse);
+const devServer = new webpackDevServer(compiler, configToUse.devServer);
+const port = configToUse.devServer?.port || 8080;
+const host = configToUse.devServer?.host || "0.0.0.0";
 
 devServer.listen(port, host, (error?: Error) => {
   if (error) {

--- a/src/scripts/stylelint/stylelint.ts
+++ b/src/scripts/stylelint/stylelint.ts
@@ -2,25 +2,28 @@
 
 import chalk from "chalk";
 import path from "path";
+import stylelint from "stylelint";
 import { SOURCE_PATH, ROOT_PATH } from "../../common/paths";
 import getConfigToUse from "../../common/getConfigToUse";
 import getFilesToUse from "../../common/getFilesToUse";
-import stylelint from "stylelint";
+import { ExosScripts } from "../../common/types";
+
 import stylelintrc = require("./.stylelintrc.js");
 
-async function main() {
+(async function main(): Promise<void> {
   // Resolve configuration to use
-  const configToUse = getConfigToUse("stylelint.js", stylelintrc);
-  console.log(configToUse.isCustom ? `Found custom lint at ${configToUse.customPath}` : "Using default lint config");
+  const configToUse = getConfigToUse(ExosScripts.stylelint, stylelintrc);
+  console.log(configToUse !== stylelintrc ? `Found custom stylelint config` : "Using default stylelint config");
 
   // Resolve files to use
-  const filesToUse = getFilesToUse("--files=", [path.join(SOURCE_PATH, "/**/*.{scss,css}")]);
-  console.log(filesToUse.isCustom ? `Found custom rule to identify files to use` : "Using default rule to identify files");
+  const defaultFilesToUse = [path.join(SOURCE_PATH, "/**/*.{scss,css}")];
+  const filesToUse = getFilesToUse("--files=", defaultFilesToUse);
+  console.log(filesToUse !== defaultFilesToUse ? `Found custom rule to identify files to use` : "Using default rule to identify files");
 
   try {
     // Lint files and get the lint result
-    const options = { config: configToUse.result, files: filesToUse.result };
-    const { errored, results, output } = await stylelint.lint(options);
+    const options = { config: configToUse, files: filesToUse };
+    const { errored, results } = await stylelint.lint(options);
 
     // Output the results and exit the process based on them
     if (errored) {
@@ -56,6 +59,4 @@ async function main() {
     console.error(chalk.red(error));
     process.exit(1);
   }
-}
-
-main();
+})();

--- a/src/scripts/test/test.ts
+++ b/src/scripts/test/test.ts
@@ -9,22 +9,23 @@ import getArgumentValue from "../../common/getArgumentValue";
 import getConfigToUse from "../../common/getConfigToUse";
 import jestConfigReact = require("./jest.config.react");
 import jestConfigLibrary = require("./jest.config.library");
+import { ExosScripts } from "../../common/types";
 import type { Config } from "@jest/types";
 
 // Choose which default configuration to use
 const isLibrary = getArgumentValue(process.argv, "type").toLowerCase() === "library";
-const jestConfig = isLibrary ? jestConfigLibrary : jestConfigReact;
+const jestConfig: Config.InitialOptions = isLibrary ? jestConfigLibrary : jestConfigReact;
 
 // Get config path (default or custom)
-const configToUse = getConfigToUse<Config.Argv>("test.js", jestConfig as any);
-console.log(configToUse.isCustom ? `Found custom test config at ${configToUse.customPath}` : "Using default test config");
+const configToUse = getConfigToUse<Config.InitialOptions>(ExosScripts.test, jestConfig);
+console.log(configToUse !== jestConfig ? `Found custom test config` : "Using default test config");
 
 // Remove current args because we don't want to run Jest
 // using the current path as base (it should use what's configured in the config file)
 const argv = process.argv.slice(2);
 
 // Set the config to use
-argv.push("--config", JSON.stringify(configToUse.result));
+argv.push("--config", JSON.stringify(configToUse));
 
 // Run Jest with the arguments
 jest.run(argv);

--- a/test/scripts/stylelint/stylelint.spec.ts
+++ b/test/scripts/stylelint/stylelint.spec.ts
@@ -3,7 +3,7 @@ import { runExosScript } from "../../test-utils";
 import type { SpawnSyncReturns } from "child_process";
 
 const MOCKS_FOLDER_PATH = path.resolve(__dirname, "./mocks");
-const errorMessage: string = "❌ There were errors while running stylelint.";
+const errorMessage = "❌ There were errors while running stylelint.";
 
 describe("stylelint E2E", () => {
   let args: string[];


### PR DESCRIPTION
This PR changes the way we can extend files. See the README for more info about it.

In the upcoming PRs, we will
* Refactor the entire library to simplify its code: we can now get all the config info and env variables once and then pass them to the scripts.
* Change the scripts to be node functions instead of command line tools.
* (nice to have) Allow configuration file (**exos.config.js**) to be written in TypeScript