### PR TITLE
fix(build,start): Move process.env.NODE_ENV to the top to affect imported files

### DIFF
--- a/src/scripts/build/build.ts
+++ b/src/scripts/build/build.ts
@@ -5,7 +5,7 @@ if (!process.env.NODE_ENV) {
 }
 
 // We need to set up process.env.NODE_ENV because
-//  the imported files will use this value
+// the imported files will use this value
 /* eslint-disable import/first */
 import chalk from 'chalk';
 import webpack from 'webpack';

--- a/src/scripts/build/build.ts
+++ b/src/scripts/build/build.ts
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = 'prod';
+}
+
+// We need to set up process.env.NODE_ENV because
+//  the imported files will use this value
+/* eslint-disable import/first */
 import chalk from 'chalk';
 import webpack from 'webpack';
 import webpackConfig from '../../webpack/webpack.config';
 import getConfigToUse from '../../common/getConfigToUse';
 import { ExosScripts } from '../../common/types';
-
-if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = 'prod';
-}
 
 const configToUse = getConfigToUse<webpack.Configuration>(ExosScripts.build, webpackConfig);
 console.log(configToUse !== webpackConfig ? 'Found custom build config' : 'Using default build config');

--- a/src/scripts/start/start.ts
+++ b/src/scripts/start/start.ts
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = 'dev';
+}
+
+// We need to set up process.env.NODE_ENV because
+//  the imported files will use this value
+/* eslint-disable import/first */
 import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import webpackConfig from '../../webpack/webpack.config';
 import getConfigToUse from '../../common/getConfigToUse';
 import { ExosScripts } from '../../common/types';
-
-if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = 'dev';
-}
 
 const configToUse = getConfigToUse<webpack.Configuration>(ExosScripts.start, webpackConfig);
 console.log(configToUse !== webpackConfig ? 'Found custom start config' : 'Using default start config');

--- a/src/scripts/start/start.ts
+++ b/src/scripts/start/start.ts
@@ -5,7 +5,7 @@ if (!process.env.NODE_ENV) {
 }
 
 // We need to set up process.env.NODE_ENV because
-//  the imported files will use this value
+// the imported files will use this value
 /* eslint-disable import/first */
 import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';

--- a/src/scripts/stylelint/stylelint.ts
+++ b/src/scripts/stylelint/stylelint.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
 import chalk from 'chalk';
-import path from 'path';
 import stylelint from 'stylelint';
-import { SOURCE_PATH, ROOT_PATH } from '../../common/paths';
+import { ROOT_PATH } from '../../common/paths';
 import getConfigToUse from '../../common/getConfigToUse';
 import getFilesToUse from '../../common/getFilesToUse';
 import { ExosScripts } from '../../common/types';


### PR DESCRIPTION
This PR fixes a bug in the `start` and `build` script: we have to set up the `process.env.NODE_ENV` env variable as the first step of the CLI, mainly because most of the imported files use this value. You don't notice it in the `build` today because by default, if the value is not present, we use `prod`. But this might change in the future.

It also removes two unused variables in the *src/scripts/stylelint/stylelint.ts* file that caused an eslint warning.