### PR TITLE
Fix: Promote localization of string literals

### DIFF
--- a/src/scripts/lint/.eslintrc.react.js
+++ b/src/scripts/lint/.eslintrc.react.js
@@ -31,6 +31,8 @@ module.exports = {
     '@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
     'react/jsx-filename-extension': ['error', { extensions: ['.tsx'] }],
     'react/jsx-props-no-spreading': 'off',
+    // Promotes localization of string literals
+    'react/jsx-no-literals': ['error', { noStrings: false }],
     'react/prop-types': 'off',
     'react/static-property-placement': ['error', 'static public field'],
     'react/function-component-definition': ['error', { namedComponents: 'function-declaration' }],


### PR DESCRIPTION
This is best practice for promoting localization of string literals within React components. You can get around this by just doing `{'string'}` but at least this will prompt folks to consider localization and store literals in a central location.