### PR TITLE
fix(start,build): Set up entry point as an object to allow extension or modifications

### DIFF
--- a/src/webpack/webpack.config.app.ts
+++ b/src/webpack/webpack.config.app.ts
@@ -29,10 +29,12 @@ const webpackConfig: webpack.Configuration = {
 
   mode: isDevelopment ? 'development' : 'production',
 
-  entry: path.resolve(ROOT_PATH, './src/index.tsx'),
+  entry: {
+    bundle: path.resolve(ROOT_PATH, './src/index.tsx'),
+  },
 
   output: {
-    filename: 'bundle.[hash:5].min.js',
+    filename: '[name].[hash:5].min.js',
     path: OUTPUT_PATH,
     publicPath: OUTPUT_PUBLIC_PATH,
   },

--- a/src/webpack/webpack.config.library.ts
+++ b/src/webpack/webpack.config.library.ts
@@ -18,10 +18,12 @@ const webpackConfig: webpack.Configuration = {
 
   mode: isDevelopment ? 'development' : 'production',
 
-  entry: path.resolve(ROOT_PATH, './src/index.tsx'),
+  entry: {
+    index: path.resolve(ROOT_PATH, './src/index.tsx'),
+  },
 
   output: {
-    filename: 'index.min.js',
+    filename: '[name].min.js',
     path: OUTPUT_PATH,
     libraryTarget: 'commonjs2',
   },


### PR DESCRIPTION
This PR fixes the webpack's `entry` point value to allow extensibility. 

For this, we replace the shorthand syntax with the object syntax, and we update the `output.filename` property to use a dynamic name.

For more info, see https://webpack.js.org/concepts/entry-points/