### PR TITLE
fix(lint): Ignore autogenerated SCSS definition files

### DIFF
--- a/src/scripts/lint/.eslintrc.react.js
+++ b/src/scripts/lint/.eslintrc.react.js
@@ -26,6 +26,7 @@ module.exports = {
       version: 'detect', // Tells eslint-plugin-react to automatically detect the version of React to use
     },
   },
+  ignorePatterns: ['**/*.scss.d.ts'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],


### PR DESCRIPTION
This PR removes from the linting the autogenerated SCSS definition files, taking advantage of the ESLint's `ignorePatterns` config property.

For more info, see https://eslint.org/docs/user-guide/configuring#ignorepatterns-in-config-files-1