### PR TITLE
fix(lint): Remove no literals check for JSX files

### DIFF
--- a/src/scripts/lint/.eslintrc.react.js
+++ b/src/scripts/lint/.eslintrc.react.js
@@ -32,8 +32,6 @@ module.exports = {
     '@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
     'react/jsx-filename-extension': ['error', { extensions: ['.tsx'] }],
     'react/jsx-props-no-spreading': 'off',
-    // Promotes localization of string literals in JSX
-    'react/jsx-no-literals': ['error', { noStrings: false }],
     'react/prop-types': 'off',
     'react/static-property-placement': ['error', 'static public field'],
     'react/function-component-definition': ['error', { namedComponents: 'function-declaration' }],


### PR DESCRIPTION
This PR removes the error displayed when linting React files with literals (aka hardcoded strings). It should be controlled by the projects instead, as it is too specific.