### PR TITLE
feat: Remove library minification. Remove resolution of scss and json files

### DIFF
--- a/src/webpack/webpack.config.app.ts
+++ b/src/webpack/webpack.config.app.ts
@@ -45,7 +45,7 @@ const webpackConfig: webpack.Configuration = {
 
   resolve: {
     alias: resolveAliases(),
-    extensions: ['.ts', '.tsx', '.scss', '.js', '.jsx', '.json'],
+    extensions: ['.ts', '.tsx', '.js', '.jsx'],
   },
 
   module: {

--- a/src/webpack/webpack.config.library.ts
+++ b/src/webpack/webpack.config.library.ts
@@ -33,11 +33,15 @@ const webpackConfig: webpack.Configuration = {
 
   resolve: {
     alias: resolveAliases(),
-    extensions: ['.ts', '.tsx', '.scss', '.js', '.jsx', '.json'],
+    extensions: ['.ts', '.tsx', '.js', '.jsx'],
   },
 
   module: {
     rules: resolveModuleRules(isDevelopment, true),
+  },
+
+  optimization: {
+    minimize: false,
   },
 
   plugins: resolvePlugins(isDevelopment, true, version),


### PR DESCRIPTION
Library bundles should not be minified. It makes debugging harder. They will be minified by the app.

Typescript only supports resolution of the following extensions: `.ts`, `.tsx`, `.js`, `.jsx`. So `.scss` and `.json` files should be imported with the extension included.