### PR TITLE
feat: Externalize all dependencies in library bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2635,6 +2635,15 @@
         "@types/webpack": "*"
       }
     },
+    "@types/webpack-node-externals": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/webpack-node-externals/-/webpack-node-externals-2.5.0.tgz",
+      "integrity": "sha512-KaWfhUQlpWknM/CMBKhV7i0vxX/N2xEy3WeaE500s4ZNxC4nLnKB+0F3gD3Fg+5octPq0nn8ZlfFR/P3dSkXpw==",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "*"
+      }
+    },
     "@types/webpack-sources": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.0.tgz",
@@ -20335,6 +20344,11 @@
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
       }
+    },
+    "webpack-node-externals": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-2.5.0.tgz",
+      "integrity": "sha512-g7/Z7Q/gsP8GkJkKZuJggn6RSb5PvxW1YD5vvmRZIxaSxAzkqjfL5n9CslVmNYlSqBVCyiqFgOqVS2IOObCSRg=="
     },
     "webpack-sources": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "tslib": "^2.0.0",
     "url-loader": "^4.0.0",
     "webpack": "^4.42.1",
-    "webpack-dev-server": "^3.10.3"
+    "webpack-dev-server": "^3.10.3",
+    "webpack-node-externals": "^2.5.0"
   },
   "devDependencies": {
     "@types/copy-webpack-plugin": "^5.0.0",
@@ -77,6 +78,7 @@
     "@types/stylelint": "^9.10.1",
     "@types/webpack": "^4.41.10",
     "@types/webpack-dev-server": "^3.10.1",
+    "@types/webpack-node-externals": "^2.5.0",
     "semantic-release": "^17.0.8",
     "typescript": "^3.9.3",
     "webpack-cli": "^3.3.11"

--- a/src/webpack/resolveExternals.ts
+++ b/src/webpack/resolveExternals.ts
@@ -1,22 +1,9 @@
 import type webpack from 'webpack';
+import nodeExternals from 'webpack-node-externals';
 
 export default (isLibrary: boolean): webpack.ExternalsElement => {
   if (isLibrary) {
-    // UMD only supports an object
-    return {
-      react: {
-        amd: 'react',
-        commonjs: 'react',
-        commonjs2: 'react',
-        root: 'React',
-      },
-      'react-dom': {
-        amd: 'react-dom',
-        commonjs: 'react-dom',
-        commonjs2: 'react-dom',
-        root: 'ReactDOM',
-      },
-    };
+    return nodeExternals();
   }
 
   return {


### PR DESCRIPTION
This was tested with the packages and app where we are using `exos-scripts`. The app runs correctly.