### PR TITLE
feat: Only compile bundled TS files

### DIFF
--- a/src/webpack/resolveModuleRules.ts
+++ b/src/webpack/resolveModuleRules.ts
@@ -46,7 +46,10 @@ export default (isDevelopment: boolean, isLibrary: boolean): webpack.RuleSetRule
   {
     test: /\.ts(x?)$/,
     include: SOURCE_PATH,
-    use: [{ loader: 'ts-loader' }],
+    use: [{
+      loader: 'ts-loader',
+      options: { onlyCompileBundledFiles: true },
+    }],
   },
   // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
   {


### PR DESCRIPTION
This change is done in order to not compile files that will be not part of the bundle (e.g. spec files).