### PR TITLE
fix(build): Remove public path definition

### DIFF
--- a/src/webpack/resolvePlugins.ts
+++ b/src/webpack/resolvePlugins.ts
@@ -5,8 +5,7 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import {
   ASSETS_PATH,
-  OUTPUT_PATH,
-  OUTPUT_PUBLIC_PATH,
+  OUTPUT_PATH
 } from '../common/paths';
 
 export default (isDevelopment: boolean, isLibrary: boolean, version: string): webpack.Plugin[] => {
@@ -19,7 +18,7 @@ export default (isDevelopment: boolean, isLibrary: boolean, version: string): we
     from: ASSETS_PATH,
     to: OUTPUT_PATH,
     ignore: ['index.ejs'],
-    context: ASSETS_PATH
+    context: ASSETS_PATH,
   }]);
   const htmlWebpackPlugin = new HtmlWebpackPlugin({
     cache: true,

--- a/src/webpack/resolvePlugins.ts
+++ b/src/webpack/resolvePlugins.ts
@@ -5,7 +5,7 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import {
   ASSETS_PATH,
-  OUTPUT_PATH
+  OUTPUT_PATH,
 } from '../common/paths';
 
 export default (isDevelopment: boolean, isLibrary: boolean, version: string): webpack.Plugin[] => {

--- a/src/webpack/resolvePlugins.ts
+++ b/src/webpack/resolvePlugins.ts
@@ -19,6 +19,7 @@ export default (isDevelopment: boolean, isLibrary: boolean, version: string): we
     from: ASSETS_PATH,
     to: OUTPUT_PATH,
     ignore: ['index.ejs'],
+    context: ASSETS_PATH
   }]);
   const htmlWebpackPlugin = new HtmlWebpackPlugin({
     cache: true,
@@ -27,7 +28,6 @@ export default (isDevelopment: boolean, isLibrary: boolean, version: string): we
     filename: path.resolve(OUTPUT_PATH, 'index.html'),
     // Arbitrary options that are sent to the template file
     isDevelopment,
-    publicPath: OUTPUT_PUBLIC_PATH,
     version,
   });
   const watchIgnorePlugin = new webpack.WatchIgnorePlugin([/scss\.d\.ts$/]);


### PR DESCRIPTION
Because this should be generic:
- It now uses the _publicPath_ of the webpack config instead of the options of the plugin
- Changes context to not append the `/public` to the path